### PR TITLE
This commit modified the makefile so the 'Get Going' tasks all run pr…

### DIFF
--- a/makefile
+++ b/makefile
@@ -15,9 +15,9 @@ github: FORCE
 	git push origin master
 
 all_tests: FORCE
-	cd $(API_DIR); make tests
-	#cd $(DB_DIR); make tests
-	cd $(SEC_DIR); make tests
+	PYTHONPATH=$(shell pwd) pytest -vv --cov=server server/tests
+	# PYTHONPATH=$(shell pwd) pytest -vv --cov=data data/tests
+	PYTHONPATH=$(shell pwd) pytest -vv --cov=security security/tests
 
 dev_env: FORCE
 	pip3 install -r $(REQ_DIR)/requirements-dev.txt


### PR DESCRIPTION
I went into the makefile and changed the all_tests: Force section. Before, the paths were not set properly.
Before:
- The makefile cd into the subdirectories server and security, losing sight of the top-level rjrtm directory
- Then, once it cd into the subdirectory, it tries to import the folder it is currently in, which cannot happen

After:
- Stays in the project root, does not cd into the subdirectories
- Uses relative paths to make sure it works across all local machines

With this change, the "Getting Going" tasks all run properly